### PR TITLE
add awakeFromNib to make sure ibdesignable elements are refreshed wit…

### DIFF
--- a/OGSwitch/OGSwitch.swift
+++ b/OGSwitch/OGSwitch.swift
@@ -90,6 +90,12 @@ public class OGSwitch : NSView {
         super.init(frame: frame);
         setup()
     }
+
+    override public func awakeFromNib() {
+        super.awakeFromNib()
+        reloadLayerSize()
+        reloadLayer()
+    }
     
     internal func setup() {
         isEnabled = true


### PR DESCRIPTION
LOVE this library thank you so much!!

I was having a tiny issue where if I set the switch up in the storyboard, it would show the default colors (green) and size until I turned the switch off and on again -- then it would switch to the IBDesignable values.

I just added an awakeFromNib() with a refresh -- if you want to do a different fix or add it yourself instead of pull requesting no prob...

Your code was so clean and easy to dig through so thanks again for a great library.